### PR TITLE
fix: Render only one footer per post

### DIFF
--- a/src/Post.jsx
+++ b/src/Post.jsx
@@ -362,6 +362,7 @@ const postsList =
                 <Widget
                   src={`${ownerId}/widget/Post`}
                   props={{ id: childId, isUnderPost: true }}
+                  key={`subpost${childId}of${postId}`}
                 />
               );
             })


### PR DESCRIPTION
In general, we need to add proper keys to all react-generated lists. 