### PR TITLE
fix: React conditional rendering bug.

### DIFF
--- a/src/Ideas.metadata.json
+++ b/src/Ideas.metadata.json
@@ -5,7 +5,7 @@
   },
   "name": "Developer Governance Gigs",
   "tags": {
-    "app": "",
-    "developer-governance": ""
+    "developer-governance": "",
+    "app": ""
   }
 }

--- a/src/KanbanBoardList.jsx
+++ b/src/KanbanBoardList.jsx
@@ -39,7 +39,7 @@ const boards = props.boards ?? [
     name: "Funding",
     id: "funding",
     config: {
-      requiredLabels: ["funding-requested"],
+      requiredLabels: ["funding"],
       columnLabels: [
         "funding-requested",
         "funding-info-submitted",

--- a/src/Post.jsx
+++ b/src/Post.jsx
@@ -26,7 +26,7 @@ const timestamp = readableDate(
 );
 
 const linkToParent =
-  isUnderPost || !parentId ? null : (
+  isUnderPost || !parentId ? (<div></div>) : (
     <div className="card-header">
       <a
         href={`https://near.social/#/devgovgigs.near/widget/Post?id=${parentId}`}
@@ -81,9 +81,9 @@ const editControl = allowedToEdit ? (
       {btnEditorWidget("Comment", "Edit as a comment")}
     </ul>
   </div>
-) : null;
+) : (<div></div>);
 
-const shareButton = props.isPreview ? null : (
+const shareButton = props.isPreview ? (<div></div>) : (
   <a
     class="card-link"
     href={`https://near.social/#/devgovgigs.near/widget/Post?id=${postId}`}
@@ -185,7 +185,7 @@ const btnCreatorWidget = (postType, icon, name) => {
   );
 };
 
-const buttonsFooter = props.isPreview ? null : (
+const buttonsFooter = props.isPreview ? (<div></div>) : (
   <div class="row">
     <div class="col-8">
       <div class="btn-group" role="group" aria-label="Basic outlined example">
@@ -290,7 +290,7 @@ const EditorWidget = (postType) => {
   );
 };
 
-const editorsFooter = props.isPreview ? null : (
+const editorsFooter = props.isPreview ? (<div></div>) : (
   <div class="row" id={`accordion${postId}`}>
     {CreatorWidget("Comment")}
     {EditorWidget("Comment")}
@@ -322,10 +322,10 @@ const postLables = post.snapshot.labels ? (
       );
     })}
   </div>
-) : null;
+) : (<div></div>);
 
 const postTitle =
-  snapshot.post_type == "Comment" ? null : (
+  snapshot.post_type == "Comment" ? (<div></div>) : (
     <h5 class="card-title">
       <div className="row justify-content-between">
         <div class="col-9">
@@ -350,10 +350,10 @@ const postExtra =
         />
       </h6>
     </div>
-  ) : null;
+  ) : (<div></div>);
 
 const postsList =
-  props.isPreview || childPostIds.length == 0 ? null : (
+  props.isPreview || childPostIds.length == 0 ? (<div></div>) : (
     <div class="row">
       <div class="collapse" id={`collapseChildPosts${postId}`}>
         {childPostIds


### PR DESCRIPTION
I just discovered that VM really does not like rendering emptry string or null in place of an html element. So when I need to do conditional rendering and not render in some case I need to return `(<div></div>)` instead of `null` or `""`.

If you do it VM will create weird hard to debug rendering bugs.