### PR TITLE
fix: Propagate referral prop through all the components down to PostEditor labels

### DIFF
--- a/common.jsx
+++ b/common.jsx
@@ -10,6 +10,7 @@ function widget(widgetName, widgetProps, key) {
     ...widgetProps,
     nearDevGovGigsContractAccountId: props.nearDevGovGigsContractAccountId,
     nearDevGovGigsWidgetsAccountId: props.nearDevGovGigsWidgetsAccountId,
+    referral: props.referral,
   };
   return (
     <Widget
@@ -29,6 +30,9 @@ function href(widgetName, linkProps) {
   if (props.nearDevGovGigsWidgetsAccountId) {
     linkProps.nearDevGovGigsWidgetsAccountId =
       props.nearDevGovGigsWidgetsAccountId;
+  }
+  if (props.referral) {
+    linkProps.referral = props.referral;
   }
   const linkPropsQuery = Object.entries(linkProps)
     .map(([key, value]) => `${key}=${value}`)

--- a/src/DevGov/Notification/Item/Left.jsx
+++ b/src/DevGov/Notification/Item/Left.jsx
@@ -11,6 +11,7 @@ function widget(widgetName, widgetProps, key) {
     ...widgetProps,
     nearDevGovGigsContractAccountId: props.nearDevGovGigsContractAccountId,
     nearDevGovGigsWidgetsAccountId: props.nearDevGovGigsWidgetsAccountId,
+    referral: props.referral,
   };
   return (
     <Widget
@@ -30,6 +31,9 @@ function href(widgetName, linkProps) {
   if (props.nearDevGovGigsWidgetsAccountId) {
     linkProps.nearDevGovGigsWidgetsAccountId =
       props.nearDevGovGigsWidgetsAccountId;
+  }
+  if (props.referral) {
+    linkProps.referral = props.referral;
   }
   const linkPropsQuery = Object.entries(linkProps)
     .map(([key, value]) => `${key}=${value}`)

--- a/src/DevGov/Notification/Item/Right.jsx
+++ b/src/DevGov/Notification/Item/Right.jsx
@@ -11,6 +11,7 @@ function widget(widgetName, widgetProps, key) {
     ...widgetProps,
     nearDevGovGigsContractAccountId: props.nearDevGovGigsContractAccountId,
     nearDevGovGigsWidgetsAccountId: props.nearDevGovGigsWidgetsAccountId,
+    referral: props.referral,
   };
   return (
     <Widget
@@ -30,6 +31,9 @@ function href(widgetName, linkProps) {
   if (props.nearDevGovGigsWidgetsAccountId) {
     linkProps.nearDevGovGigsWidgetsAccountId =
       props.nearDevGovGigsWidgetsAccountId;
+  }
+  if (props.referral) {
+    linkProps.referral = props.referral;
   }
   const linkPropsQuery = Object.entries(linkProps)
     .map(([key, value]) => `${key}=${value}`)

--- a/src/gigs-board/components/boards/KanbanBoard.jsx
+++ b/src/gigs-board/components/boards/KanbanBoard.jsx
@@ -11,6 +11,7 @@ function widget(widgetName, widgetProps, key) {
     ...widgetProps,
     nearDevGovGigsContractAccountId: props.nearDevGovGigsContractAccountId,
     nearDevGovGigsWidgetsAccountId: props.nearDevGovGigsWidgetsAccountId,
+    referral: props.referral,
   };
   return (
     <Widget
@@ -30,6 +31,9 @@ function href(widgetName, linkProps) {
   if (props.nearDevGovGigsWidgetsAccountId) {
     linkProps.nearDevGovGigsWidgetsAccountId =
       props.nearDevGovGigsWidgetsAccountId;
+  }
+  if (props.referral) {
+    linkProps.referral = props.referral;
   }
   const linkPropsQuery = Object.entries(linkProps)
     .map(([key, value]) => `${key}=${value}`)

--- a/src/gigs-board/components/layout/Controls.jsx
+++ b/src/gigs-board/components/layout/Controls.jsx
@@ -11,6 +11,7 @@ function widget(widgetName, widgetProps, key) {
     ...widgetProps,
     nearDevGovGigsContractAccountId: props.nearDevGovGigsContractAccountId,
     nearDevGovGigsWidgetsAccountId: props.nearDevGovGigsWidgetsAccountId,
+    referral: props.referral,
   };
   return (
     <Widget
@@ -30,6 +31,9 @@ function href(widgetName, linkProps) {
   if (props.nearDevGovGigsWidgetsAccountId) {
     linkProps.nearDevGovGigsWidgetsAccountId =
       props.nearDevGovGigsWidgetsAccountId;
+  }
+  if (props.referral) {
+    linkProps.referral = props.referral;
   }
   const linkPropsQuery = Object.entries(linkProps)
     .map(([key, value]) => `${key}=${value}`)
@@ -126,7 +130,6 @@ return (
         {widget("components.posts.PostEditor", {
           postType: "Comment",
           parentId: null,
-          referral: props.referral,
         })}
       </div>
       <div
@@ -137,7 +140,6 @@ return (
         {widget("components.posts.PostEditor", {
           postType: "Idea",
           parentId: null,
-          referral: props.referral,
         })}
       </div>
       <div
@@ -148,7 +150,6 @@ return (
         {widget("components.posts.PostEditor", {
           postType: "Submission",
           parentId: null,
-          referral: props.referral,
         })}
       </div>
       <div
@@ -159,7 +160,6 @@ return (
         {widget("components.posts.PostEditor", {
           postType: "Attestation",
           parentId: null,
-          referral: props.referral,
         })}
       </div>
       <div
@@ -170,7 +170,6 @@ return (
         {widget("components.posts.PostEditor", {
           postType: "Sponsorship",
           parentId: null,
-          referral: props.referral,
         })}
       </div>
     </div>

--- a/src/gigs-board/components/layout/Navbar.jsx
+++ b/src/gigs-board/components/layout/Navbar.jsx
@@ -11,6 +11,7 @@ function widget(widgetName, widgetProps, key) {
     ...widgetProps,
     nearDevGovGigsContractAccountId: props.nearDevGovGigsContractAccountId,
     nearDevGovGigsWidgetsAccountId: props.nearDevGovGigsWidgetsAccountId,
+    referral: props.referral,
   };
   return (
     <Widget
@@ -30,6 +31,9 @@ function href(widgetName, linkProps) {
   if (props.nearDevGovGigsWidgetsAccountId) {
     linkProps.nearDevGovGigsWidgetsAccountId =
       props.nearDevGovGigsWidgetsAccountId;
+  }
+  if (props.referral) {
+    linkProps.referral = props.referral;
   }
   const linkPropsQuery = Object.entries(linkProps)
     .map(([key, value]) => `${key}=${value}`)

--- a/src/gigs-board/components/layout/Page.jsx
+++ b/src/gigs-board/components/layout/Page.jsx
@@ -11,6 +11,7 @@ function widget(widgetName, widgetProps, key) {
     ...widgetProps,
     nearDevGovGigsContractAccountId: props.nearDevGovGigsContractAccountId,
     nearDevGovGigsWidgetsAccountId: props.nearDevGovGigsWidgetsAccountId,
+    referral: props.referral,
   };
   return (
     <Widget
@@ -31,6 +32,9 @@ function href(widgetName, linkProps) {
     linkProps.nearDevGovGigsWidgetsAccountId =
       props.nearDevGovGigsWidgetsAccountId;
   }
+  if (props.referral) {
+    linkProps.referral = props.referral;
+  }
   const linkPropsQuery = Object.entries(linkProps)
     .map(([key, value]) => `${key}=${value}`)
     .join("&");
@@ -43,7 +47,9 @@ function href(widgetName, linkProps) {
 return (
   <>
     {widget("components.layout.Controls")}
-    {widget("components.layout.Navbar", { children: props.navbarChildren })}
+    {widget("components.layout.Navbar", {
+      children: props.navbarChildren,
+    })}
     {props.children}
   </>
 );

--- a/src/gigs-board/components/layout/Search.jsx
+++ b/src/gigs-board/components/layout/Search.jsx
@@ -11,6 +11,7 @@ function widget(widgetName, widgetProps, key) {
     ...widgetProps,
     nearDevGovGigsContractAccountId: props.nearDevGovGigsContractAccountId,
     nearDevGovGigsWidgetsAccountId: props.nearDevGovGigsWidgetsAccountId,
+    referral: props.referral,
   };
   return (
     <Widget
@@ -30,6 +31,9 @@ function href(widgetName, linkProps) {
   if (props.nearDevGovGigsWidgetsAccountId) {
     linkProps.nearDevGovGigsWidgetsAccountId =
       props.nearDevGovGigsWidgetsAccountId;
+  }
+  if (props.referral) {
+    linkProps.referral = props.referral;
   }
   const linkPropsQuery = Object.entries(linkProps)
     .map(([key, value]) => `${key}=${value}`)

--- a/src/gigs-board/components/posts/CompactPost.jsx
+++ b/src/gigs-board/components/posts/CompactPost.jsx
@@ -11,6 +11,7 @@ function widget(widgetName, widgetProps, key) {
     ...widgetProps,
     nearDevGovGigsContractAccountId: props.nearDevGovGigsContractAccountId,
     nearDevGovGigsWidgetsAccountId: props.nearDevGovGigsWidgetsAccountId,
+    referral: props.referral,
   };
   return (
     <Widget
@@ -30,6 +31,9 @@ function href(widgetName, linkProps) {
   if (props.nearDevGovGigsWidgetsAccountId) {
     linkProps.nearDevGovGigsWidgetsAccountId =
       props.nearDevGovGigsWidgetsAccountId;
+  }
+  if (props.referral) {
+    linkProps.referral = props.referral;
   }
   const linkPropsQuery = Object.entries(linkProps)
     .map(([key, value]) => `${key}=${value}`)

--- a/src/gigs-board/components/posts/List.jsx
+++ b/src/gigs-board/components/posts/List.jsx
@@ -16,6 +16,7 @@ function widget(widgetName, widgetProps, key) {
     ...widgetProps,
     nearDevGovGigsContractAccountId: props.nearDevGovGigsContractAccountId,
     nearDevGovGigsWidgetsAccountId: props.nearDevGovGigsWidgetsAccountId,
+    referral: props.referral,
   };
   return (
     <Widget
@@ -36,6 +37,9 @@ function href(widgetName, linkProps) {
     linkProps.nearDevGovGigsWidgetsAccountId =
       props.nearDevGovGigsWidgetsAccountId;
   }
+  if (props.referral) {
+    linkProps.referral = props.referral;
+  }
   const linkPropsQuery = Object.entries(linkProps)
     .map(([key, value]) => `${key}=${value}`)
     .join("&");
@@ -54,7 +58,6 @@ const renderItem =
         `components.posts.Post`,
         {
           id: postId,
-          referral: props.referral,
           expandable: true,
           defaultExpanded: false,
         },

--- a/src/gigs-board/components/posts/Post.jsx
+++ b/src/gigs-board/components/posts/Post.jsx
@@ -11,6 +11,7 @@ function widget(widgetName, widgetProps, key) {
     ...widgetProps,
     nearDevGovGigsContractAccountId: props.nearDevGovGigsContractAccountId,
     nearDevGovGigsWidgetsAccountId: props.nearDevGovGigsWidgetsAccountId,
+    referral: props.referral,
   };
   return (
     <Widget
@@ -31,6 +32,9 @@ function href(widgetName, linkProps) {
     linkProps.nearDevGovGigsWidgetsAccountId =
       props.nearDevGovGigsWidgetsAccountId;
   }
+  if (props.referral) {
+    linkProps.referral = props.referral;
+  }
   const linkPropsQuery = Object.entries(linkProps)
     .map(([key, value]) => `${key}=${value}`)
     .join("&");
@@ -47,7 +51,6 @@ const post =
 if (!post) {
   return <div>Loading ...</div>;
 }
-const referral = props.referral;
 
 const snapshot = post.snapshot;
 // If this post is displayed under another post. Used to limit the size.
@@ -79,7 +82,7 @@ const linkToParent =
     <div key="link-to-parent"></div>
   ) : (
     <div className="card-header" key="link-to-parent">
-      <a href={href("Post", { id: parentId, referral })}>
+      <a href={href("Post", { id: parentId })}>
         <i class="bi bi-arrow-90deg-up"></i>Go to parent{" "}
       </a>
     </div>
@@ -138,7 +141,7 @@ const shareButton = props.isPreview ? (
 ) : (
   <a
     class="card-link"
-    href={href("Post", { id: postId, referral })}
+    href={href("Post", { id: postId })}
     role="button"
     target="_blank"
     title="Open in new tab"
@@ -306,7 +309,6 @@ const CreatorWidget = (postType) => {
         postType,
         parentId: postId,
         mode: "Create",
-        referral: props.referral,
       })}
     </div>
   );
@@ -331,7 +333,6 @@ const EditorWidget = (postType) => {
         token: post.snapshot.sponsorship_token,
         supervisor: post.snapshot.supervisor,
         githubLink: post.snapshot.github_link,
-        referral: props.referral,
       })}
     </div>
   );
@@ -415,7 +416,7 @@ const postsList =
         {childPostIds.map((childId) =>
           widget(
             "components.posts.Post",
-            { id: childId, isUnderPost: true, referral: props.referral },
+            { id: childId, isUnderPost: true },
             `subpost${childId}of${postId}`
           )
         )}

--- a/src/gigs-board/components/posts/PostEditor.jsx
+++ b/src/gigs-board/components/posts/PostEditor.jsx
@@ -11,6 +11,7 @@ function widget(widgetName, widgetProps, key) {
     ...widgetProps,
     nearDevGovGigsContractAccountId: props.nearDevGovGigsContractAccountId,
     nearDevGovGigsWidgetsAccountId: props.nearDevGovGigsWidgetsAccountId,
+    referral: props.referral,
   };
   return (
     <Widget
@@ -30,6 +31,9 @@ function href(widgetName, linkProps) {
   if (props.nearDevGovGigsWidgetsAccountId) {
     linkProps.nearDevGovGigsWidgetsAccountId =
       props.nearDevGovGigsWidgetsAccountId;
+  }
+  if (props.referral) {
+    linkProps.referral = props.referral;
   }
   const linkPropsQuery = Object.entries(linkProps)
     .map(([key, value]) => `${key}=${value}`)

--- a/src/gigs-board/components/teams/LabelsPermissions.jsx
+++ b/src/gigs-board/components/teams/LabelsPermissions.jsx
@@ -11,6 +11,7 @@ function widget(widgetName, widgetProps, key) {
     ...widgetProps,
     nearDevGovGigsContractAccountId: props.nearDevGovGigsContractAccountId,
     nearDevGovGigsWidgetsAccountId: props.nearDevGovGigsWidgetsAccountId,
+    referral: props.referral,
   };
   return (
     <Widget
@@ -30,6 +31,9 @@ function href(widgetName, linkProps) {
   if (props.nearDevGovGigsWidgetsAccountId) {
     linkProps.nearDevGovGigsWidgetsAccountId =
       props.nearDevGovGigsWidgetsAccountId;
+  }
+  if (props.referral) {
+    linkProps.referral = props.referral;
   }
   const linkPropsQuery = Object.entries(linkProps)
     .map(([key, value]) => `${key}=${value}`)

--- a/src/gigs-board/components/teams/TeamInfo.jsx
+++ b/src/gigs-board/components/teams/TeamInfo.jsx
@@ -11,6 +11,7 @@ function widget(widgetName, widgetProps, key) {
     ...widgetProps,
     nearDevGovGigsContractAccountId: props.nearDevGovGigsContractAccountId,
     nearDevGovGigsWidgetsAccountId: props.nearDevGovGigsWidgetsAccountId,
+    referral: props.referral,
   };
   return (
     <Widget
@@ -30,6 +31,9 @@ function href(widgetName, linkProps) {
   if (props.nearDevGovGigsWidgetsAccountId) {
     linkProps.nearDevGovGigsWidgetsAccountId =
       props.nearDevGovGigsWidgetsAccountId;
+  }
+  if (props.referral) {
+    linkProps.referral = props.referral;
   }
   const linkPropsQuery = Object.entries(linkProps)
     .map(([key, value]) => `${key}=${value}`)

--- a/src/gigs-board/pages/Boards.jsx
+++ b/src/gigs-board/pages/Boards.jsx
@@ -11,6 +11,7 @@ function widget(widgetName, widgetProps, key) {
     ...widgetProps,
     nearDevGovGigsContractAccountId: props.nearDevGovGigsContractAccountId,
     nearDevGovGigsWidgetsAccountId: props.nearDevGovGigsWidgetsAccountId,
+    referral: props.referral,
   };
   return (
     <Widget
@@ -30,6 +31,9 @@ function href(widgetName, linkProps) {
   if (props.nearDevGovGigsWidgetsAccountId) {
     linkProps.nearDevGovGigsWidgetsAccountId =
       props.nearDevGovGigsWidgetsAccountId;
+  }
+  if (props.referral) {
+    linkProps.referral = props.referral;
   }
   const linkPropsQuery = Object.entries(linkProps)
     .map(([key, value]) => `${key}=${value}`)
@@ -137,4 +141,6 @@ const pageContent = (
   </div>
 );
 
-return widget("components.layout.Page", { children: pageContent });
+return widget("components.layout.Page", {
+  children: pageContent,
+});

--- a/src/gigs-board/pages/Feed.jsx
+++ b/src/gigs-board/pages/Feed.jsx
@@ -11,6 +11,7 @@ function widget(widgetName, widgetProps, key) {
     ...widgetProps,
     nearDevGovGigsContractAccountId: props.nearDevGovGigsContractAccountId,
     nearDevGovGigsWidgetsAccountId: props.nearDevGovGigsWidgetsAccountId,
+    referral: props.referral,
   };
   return (
     <Widget
@@ -30,6 +31,9 @@ function href(widgetName, linkProps) {
   if (props.nearDevGovGigsWidgetsAccountId) {
     linkProps.nearDevGovGigsWidgetsAccountId =
       props.nearDevGovGigsWidgetsAccountId;
+  }
+  if (props.referral) {
+    linkProps.referral = props.referral;
   }
   const linkPropsQuery = Object.entries(linkProps)
     .map(([key, value]) => `${key}=${value}`)

--- a/src/gigs-board/pages/Post.jsx
+++ b/src/gigs-board/pages/Post.jsx
@@ -11,6 +11,7 @@ function widget(widgetName, widgetProps, key) {
     ...widgetProps,
     nearDevGovGigsContractAccountId: props.nearDevGovGigsContractAccountId,
     nearDevGovGigsWidgetsAccountId: props.nearDevGovGigsWidgetsAccountId,
+    referral: props.referral,
   };
   return (
     <Widget
@@ -31,6 +32,9 @@ function href(widgetName, linkProps) {
     linkProps.nearDevGovGigsWidgetsAccountId =
       props.nearDevGovGigsWidgetsAccountId;
   }
+  if (props.referral) {
+    linkProps.referral = props.referral;
+  }
   const linkPropsQuery = Object.entries(linkProps)
     .map(([key, value]) => `${key}=${value}`)
     .join("&");
@@ -41,5 +45,7 @@ function href(widgetName, linkProps) {
 /* END_INCLUDE: "common.jsx" */
 
 return widget("components.layout.Page", {
-  children: widget("components.posts.Post", { id: props.id }),
+  children: widget("components.posts.Post", {
+    id: props.id,
+  }),
 });

--- a/src/gigs-board/pages/Teams.jsx
+++ b/src/gigs-board/pages/Teams.jsx
@@ -11,6 +11,7 @@ function widget(widgetName, widgetProps, key) {
     ...widgetProps,
     nearDevGovGigsContractAccountId: props.nearDevGovGigsContractAccountId,
     nearDevGovGigsWidgetsAccountId: props.nearDevGovGigsWidgetsAccountId,
+    referral: props.referral,
   };
   return (
     <Widget
@@ -30,6 +31,9 @@ function href(widgetName, linkProps) {
   if (props.nearDevGovGigsWidgetsAccountId) {
     linkProps.nearDevGovGigsWidgetsAccountId =
       props.nearDevGovGigsWidgetsAccountId;
+  }
+  if (props.referral) {
+    linkProps.referral = props.referral;
   }
   const linkPropsQuery = Object.entries(linkProps)
     .map(([key, value]) => `${key}=${value}`)
@@ -64,4 +68,6 @@ const pageContent = (
   </div>
 );
 
-return widget("components.layout.Page", { children: pageContent });
+return widget("components.layout.Page", {
+  children: pageContent,
+});


### PR DESCRIPTION
Resolves #9 and #39.

Note, it was actually just a small change to the `common.jsx`, which was then applied to all the widgets with `npm run build`.