### PR TITLE
chore: Minor UI improvement to prevent page layout jumps

### DIFF
--- a/src/gigs-board/components/layout/Controls.jsx
+++ b/src/gigs-board/components/layout/Controls.jsx
@@ -48,7 +48,10 @@ return (
   <div class="card border-secondary mb-2">
     <div class="nav navbar navbar-expand-lg bg-body-tertiary">
       <div class="container-fluid">
-        <div class="navbar-brand">
+        <div
+          class="navbar-brand"
+          style={{ height: "2.5em", width: "2.5em", minWidth: "2.5em" }}
+        >
           <Widget
             src="mob.near/widget/ProfileImage"
             props={{


### PR DESCRIPTION
I preallocate the block height and width for the avatar, so it does not change its size after it is loaded. You could observe the top bar jumping after the avatar widget getting loaded. With this small fix, the parent `div` will have a const size, and thus the layout will not change its size over time.