### PR TITLE
feat: Draft implementation of "Move to X" button for the posts on the Kanban Board

### DIFF
--- a/src/gigs-board/components/posts/CompactPost.jsx
+++ b/src/gigs-board/components/posts/CompactPost.jsx
@@ -44,6 +44,7 @@ function href(widgetName, linkProps) {
 }
 /* END_INCLUDE: "common.jsx" */
 
+const footer = props.footer;
 const postId = props.post.id ?? (props.id ? parseInt(props.id) : 0);
 const post =
   props.post ??
@@ -160,6 +161,7 @@ return (
       {postTitle}
       {descriptionArea}
       {postLables}
+      {footer}
     </div>
   </Card>
 );


### PR DESCRIPTION
This is a draft implementation of the low-hanging fruit solution described in #46.

<img width="883" alt="image" src="https://user-images.githubusercontent.com/304265/223170259-4ccfd418-2bb5-4384-a59e-c458a8617238.png">

Check it on testnet: https://test.near.social/#/gigs.frol14.testnet/widget/gigs-board.pages.Boards?selectedBoardId=nearsocial

TODO:
* [ ] Do not display the button to those users who don't have permission to edit the labels
* [ ] Improve the design of the button
* [ ] Consider if there should be a button to move back (e.g. if it was moved by mistake)
* [ ] Consider making a special prop flag for a board where this "Move to" is applicable, as it does not make sense to move a post from a "widget" to "integration".
* [ ] Notify the involved parties about the update - it is not a blocker, but worth to think about