### PR TITLE
hot fix z-index so liked person icons are beneath banner

### DIFF
--- a/src/gigs-board/components/layout/Page.jsx
+++ b/src/gigs-board/components/layout/Page.jsx
@@ -51,7 +51,7 @@ const Banner = styled.div`
     width: 100vw;
     height: 100px;
     background: #232323;
-    z-index: 2;
+    z-index: 11;
     margin-top: -24px;
 
     overflow: hidden;
@@ -62,7 +62,7 @@ const Logo = styled.div`
    {
     position: fixed;
     padding: 32px 0;
-    z-index: 4;
+    z-index: 13;
     margin-top: -24px;
 
     img {
@@ -93,7 +93,7 @@ const Gradient = styled.div`
     );
     opacity: 0.22;
     filter: blur(17vw);
-    z-index: 3;
+    z-index: 12;
   }
 `;
 


### PR DESCRIPTION
Before the fix:
<img width="559" alt="image" src="https://user-images.githubusercontent.com/13259400/227533557-d7aa618d-60e9-4807-88b6-3b31d6175205.png">


After this fix:
<img width="483" alt="image" src="https://user-images.githubusercontent.com/13259400/227533791-78063946-7d95-4cc4-8cd1-8a73ee7fc796.png">
