### PR TITLE
integrate hottest post on the navbar

### DIFF
--- a/src/gigs-board/components/layout/Navbar.jsx
+++ b/src/gigs-board/components/layout/Navbar.jsx
@@ -57,7 +57,7 @@ return (
           </li>
           <li class="nav-item">
             <a class="nav-link active" href={href("Feed", { recency: "all" })}>
-              <i class="bi-fire"> </i>
+              <i class="bi-envelope-fill"> </i>
               Recent
             </a>
           </li>
@@ -68,6 +68,12 @@ return (
             >
               <i class="bi-repeat"> </i>
               Recurrent
+            </a>
+          </li>
+          <li class="nav-item">
+            <a class="nav-link active" href={href("Feed", { recency: "hot" })}>
+              <i class="bi-fire"> </i>
+              Hottest
             </a>
           </li>
           <li class="nav-item">

--- a/src/gigs-board/components/posts/List.jsx
+++ b/src/gigs-board/components/posts/List.jsx
@@ -49,7 +49,9 @@ function href(widgetName, linkProps) {
 }
 /* END_INCLUDE: "common.jsx" */
 
-console.log(props);
+initState({
+  period: "week",
+});
 
 function defaultRenderItem(postId, additionalProps) {
   if (!additionalProps) {
@@ -148,6 +150,76 @@ if (props.searchResult) {
   postIds = Near.view(nearDevGovGigsContractAccountId, "get_children_ids");
 }
 
+const ONE_DAY = 60 * 60 * 24 * 1000;
+const ONE_WEEK = 60 * 60 * 24 * 1000 * 7;
+const ONE_MONTH = 60 * 60 * 24 * 1000 * 30;
+
+function getHotnessScore(post) {
+  //post.id - shows the age of the post, should grow exponentially, since newer posts are more important
+  //post.likes.length - linear value
+  const age = Math.pow(post.id, 5);
+  const comments = post.comments;
+  const commentAge = comments.reduce((sum, age) => sum + Math.pow(age, 5), 0);
+  const totalAge = age + commentAge;
+  //use log functions to make likes score and exponentially big age score close to each other
+  return Math.log10(post.likes.length) + Math.log(Math.log10(totalAge));
+}
+
+const getPeriodText = (period) => {
+  let text = "Last 24 hours";
+  if (period === "week") {
+    text = "Last week";
+  }
+  if (period === "month") {
+    text = "Last month";
+  }
+  return text;
+};
+
+const findHottestsPosts = (postIds, period) => {
+  let allPosts;
+  if (!state.allPosts) {
+    allPosts = Near.view("devgovgigs.near", "get_posts");
+    if (!allPosts) {
+      return [];
+    }
+    State.update({ allPosts });
+  } else {
+    allPosts = state.allPosts;
+  }
+  let postIdsSet = new Set(postIds);
+  let posts = allPosts.filter((post) => postIdsSet.has(post.id));
+
+  let periodTime = ONE_DAY;
+  if (period === "week") {
+    periodTime = ONE_WEEK;
+  }
+  if (period === "month") {
+    periodTime = ONE_MONTH;
+  }
+  const periodLimitedPosts = posts.filter((post) => {
+    const timestamp = post.snapshot.timestamp / 1000000;
+    return Date.now() - timestamp < periodTime;
+  });
+  const modifiedPosts = periodLimitedPosts.map((post) => {
+    const comments =
+      Near.view("devgovgigs.near", "get_children_ids", {
+        post_id: post.id,
+      }) || [];
+    post = { ...post, comments };
+    return {
+      ...post,
+      postScore: getHotnessScore(post),
+    };
+  });
+  modifiedPosts.sort((a, b) => b.postScore - a.postScore);
+  return modifiedPosts.map((post) => post.id);
+};
+
+if (props.recency == "hot") {
+  postIds = findHottestsPosts(postIds, state.period);
+}
+
 const loader = (
   <div className="loader" key={"loader"}>
     <span
@@ -162,7 +234,8 @@ const loader = (
 if (postIds === null) {
   return loader;
 }
-const initialItems = props.searchResult ? postIds : postIds.reverse();
+const initialItems =
+  props.searchResult || props.recency == "hot" ? postIds : postIds.reverse();
 //const initialItems = postIds.map(postId => ({ id: postId, ...Near.view(nearDevGovGigsContractAccountId, "get_post", { post_id: postId }) }));
 
 // const computeFetchFrom = (items, limit) => {
@@ -260,13 +333,73 @@ const items = state.items ? state.items.slice(0, state.displayCount) : [];
 console.log(items);
 const renderedItems = items.map(cachedRenderItem);
 
+const Head =
+  props.recency == "hot" ? (
+    <div class="row">
+      <div class="fs-5 col-6 align-self-center">
+        <i class="bi-fire"></i>
+        <span>Hottest Posts</span>
+      </div>
+      <div class="col-6 dropdown d-flex justify-content-end">
+        <a
+          class="btn btn-secondary dropdown-toggle"
+          href="#"
+          role="button"
+          id="dropdownMenuLink"
+          data-bs-toggle="dropdown"
+          aria-expanded="false"
+        >
+          {getPeriodText(state.period)}
+        </a>
+
+        <ul class="dropdown-menu" aria-labelledby="dropdownMenuLink">
+          <li>
+            <button
+              class="dropdown-item"
+              onClick={() => {
+                State.update({ period: "day" });
+              }}
+            >
+              {getPeriodText("day")}
+            </button>
+          </li>
+          <li>
+            <button
+              class="dropdown-item"
+              onClick={() => {
+                State.update({ period: "week" });
+              }}
+            >
+              {getPeriodText("week")}
+            </button>
+          </li>
+          <li>
+            <button
+              class="dropdown-item"
+              onClick={() => {
+                State.update({ period: "month" });
+              }}
+            >
+              {getPeriodText("month")}
+            </button>
+          </li>
+        </ul>
+      </div>
+    </div>
+  ) : (
+    <></>
+  );
+
 return (
-  <InfiniteScroll
-    pageStart={0}
-    loadMore={makeMoreItems}
-    hasMore={state.displayCount < state.items.length}
-    loader={loader}
-  >
-    {renderedItems}
-  </InfiniteScroll>
+  <>
+    {Head}
+    <InfiniteScroll
+      pageStart={0}
+      loadMore={makeMoreItems}
+      hasMore={state.displayCount < state.items.length}
+      loader={loader}
+    >
+      {renderedItems}
+    </InfiniteScroll>
+  </>
 );

--- a/src/gigs-board/components/posts/List.jsx
+++ b/src/gigs-board/components/posts/List.jsx
@@ -149,28 +149,6 @@ function intersectPostsWithAuthor(postIds) {
   return postIds;
 }
 
-let postIds;
-if (props.searchResult) {
-  postIds = props.searchResult.postIds;
-  postIds = intersectPostsWithLabel(postIds);
-  postIds = intersectPostsWithAuthor(postIds);
-} else if (props.label) {
-  postIds = getPostsByLabel();
-  postIds = intersectPostsWithAuthor(postIds);
-} else if (props.author) {
-  postIds = getPostsByAuthor();
-} else if (props.recency == "all") {
-  postIds = Near.view(nearDevGovGigsContractAccountId, "get_all_post_ids");
-  if (postIds) {
-    postIds.reverse();
-  }
-} else {
-  postIds = Near.view(nearDevGovGigsContractAccountId, "get_children_ids");
-  if (postIds) {
-    postIds.reverse();
-  }
-}
-
 const ONE_DAY = 60 * 60 * 24 * 1000;
 const ONE_WEEK = 60 * 60 * 24 * 1000 * 7;
 const ONE_MONTH = 60 * 60 * 24 * 1000 * 30;
@@ -236,6 +214,28 @@ const findHottestsPosts = (postIds, period) => {
   modifiedPosts.sort((a, b) => b.postScore - a.postScore);
   return modifiedPosts.map((post) => post.id);
 };
+
+let postIds;
+if (props.searchResult) {
+  postIds = props.searchResult.postIds;
+  postIds = intersectPostsWithLabel(postIds);
+  postIds = intersectPostsWithAuthor(postIds);
+} else if (props.label) {
+  postIds = getPostsByLabel();
+  postIds = intersectPostsWithAuthor(postIds);
+} else if (props.author) {
+  postIds = getPostsByAuthor();
+} else if (props.recency == "all") {
+  postIds = Near.view(nearDevGovGigsContractAccountId, "get_all_post_ids");
+  if (postIds) {
+    postIds.reverse();
+  }
+} else {
+  postIds = Near.view(nearDevGovGigsContractAccountId, "get_children_ids");
+  if (postIds) {
+    postIds.reverse();
+  }
+}
 
 if (props.recency == "hot") {
   postIds = findHottestsPosts(postIds, state.period);

--- a/src/gigs-board/components/posts/List.jsx
+++ b/src/gigs-board/components/posts/List.jsx
@@ -96,15 +96,30 @@ const initialRenderLimit = props.initialRenderLimit ?? 3;
 const addDisplayCount = props.nextLimit ?? initialRenderLimit;
 
 function getPostsByLabel() {
-  return Near.view(nearDevGovGigsContractAccountId, "get_posts_by_label", {
-    label: props.label,
-  });
+  let postIds = Near.view(
+    nearDevGovGigsContractAccountId,
+    "get_posts_by_label",
+    {
+      label: props.label,
+    }
+  );
+  if (postIds) {
+    postIds.reverse();
+  }
+  return postIds;
 }
 
 function getPostsByAuthor() {
-  return Near.view(nearDevGovGigsContractAccountId, "get_posts_by_author", {
-    author: props.author,
-  });
+  let postIds = Near.view(
+    nearDevGovGigsContractAccountId,
+    "get_posts_by_author",
+    {
+      author: props.author,
+    }
+  );
+  if (postIds) {
+    postIds.reverse();
+  }
 }
 
 function intersectPostsWithLabel(postIds) {
@@ -146,8 +161,14 @@ if (props.searchResult) {
   postIds = getPostsByAuthor();
 } else if (props.recency == "all") {
   postIds = Near.view(nearDevGovGigsContractAccountId, "get_all_post_ids");
+  if (postIds) {
+    postIds.reverse();
+  }
 } else {
   postIds = Near.view(nearDevGovGigsContractAccountId, "get_children_ids");
+  if (postIds) {
+    postIds.reverse();
+  }
 }
 
 const ONE_DAY = 60 * 60 * 24 * 1000;
@@ -234,8 +255,7 @@ const loader = (
 if (postIds === null) {
   return loader;
 }
-const initialItems =
-  props.searchResult || props.recency == "hot" ? postIds : postIds.reverse();
+const initialItems = postIds;
 //const initialItems = postIds.map(postId => ({ id: postId, ...Near.view(nearDevGovGigsContractAccountId, "get_post", { post_id: postId }) }));
 
 // const computeFetchFrom = (items, limit) => {
@@ -393,13 +413,20 @@ const Head =
 return (
   <>
     {Head}
-    <InfiniteScroll
-      pageStart={0}
-      loadMore={makeMoreItems}
-      hasMore={state.displayCount < state.items.length}
-      loader={loader}
-    >
-      {renderedItems}
-    </InfiniteScroll>
+    {state.items.length > 0 ? (
+      <InfiniteScroll
+        pageStart={0}
+        loadMore={makeMoreItems}
+        hasMore={state.displayCount < state.items.length}
+        loader={loader}
+      >
+        {renderedItems}
+      </InfiniteScroll>
+    ) : (
+      <p class="text-secondary">
+        No posts {props.searchResult ? "matches search" : ""} in
+        {getPeriodText(state.period).toLowerCase()}
+      </p>
+    )}
   </>
 );

--- a/src/gigs-board/components/posts/Search.jsx
+++ b/src/gigs-board/components/posts/Search.jsx
@@ -666,9 +666,9 @@ const showMoreSearchResults = () => {
 };
 
 return (
-  <div class="pb-2">
+  <div>
     <div
-      className="d-flex"
+      className="d-flex mb-2"
       style={{
         height: "38px",
       }}
@@ -709,7 +709,7 @@ return (
       state.processedQuery.length > 0 &&
       state.term.toLowerCase().trim() !== state.processedQuery.join(" ") && (
         <div class="mb-2" style={{ "font-family": "monospace" }}>
-          No results for {state.term}. Looking for
+          Looking for
           <strong>{state.processedQuery.join(" ")}</strong>:
         </div>
       )}


### PR DESCRIPTION
Integrate @p516entropy and @Markeljan's work of hottest posts on navbar. Also make it works together with search, filter by labels/authors.

Preview:
<img width="1417" alt="image" src="https://user-images.githubusercontent.com/13259400/232010203-510e921d-8eb1-45b1-86de-8ecfdbfc4647.png">

https://near.social/#/bo.near/widget/gigs-board.pages.Feed?recency=hot&nearDevGovGigsContractAccountId=devgovgigs.near